### PR TITLE
Change name; add map_object; add tests for map_object

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,14 @@ If the function takes additional arguments, you can use a wrapper function to ov
 
 ```
 
+Or even:
+
+```python
+>>> r.map_object(lambda x: fun(x, "this can be forgotten"), [2, 2, [3, 3, ], {"a": 5}])
+[4, 4, [9, 9], {'a': 25}]
+
+```
+
 # Examples
 
 First of all, all these functions will work the very same way as their original counterparts (not for `signif`, which does not have one):

--- a/README.md
+++ b/README.md
@@ -6,12 +6,16 @@ The package is useful mainly for presentation purposes, but in some cases, it ca
 
 `rounder` offers you four functions for rounding complex objects:
 
-* `round_object(x, digits=0, use_copy=False)`, which rounds `x` to `digits` decimal places
-* `floor_object(x, use_copy=False)`, which rounds `x` down to the nearest integer
-* `ceil_object(x, use_copy=False)`, which rounds `x` up to the nearest integer
-* `signif_object(x, digits, use_copy=False)`, which rounds `x` to `digits` significant digits
+* `round_object(obj, digits=0, use_copy=False)`, which rounds `x` to `digits` decimal places
+* `floor_object(obj, use_copy=False)`, which rounds `x` down to the nearest integer
+* `ceil_object(obj, use_copy=False)`, which rounds `x` up to the nearest integer
+* `signif_object(obj, digits, use_copy=False)`, which rounds `x` to `digits` significant digits
 
-but it also offers a function for rounding numbers to significant digits:
+In addition, `rounder` comes with a generalized function:
+
+* `map_obj(func, obj, use_copy=False)`, which runs callable `func`, which takes a number as an argument and returns a number, to all numbers across the object.
+
+`rounder` also offers a function for rounding numbers to significant digits:
 
 * `signif(x, digits)`, which rounds `x` (either an int or a float) to `digits` significant digits
 
@@ -152,6 +156,42 @@ And you will get this:
 
 Piece of cake! Note that we used `use_copy=True`, which means that `rounded_x` is a deepcopy of `x`, so the original dictionary has not been affected anyway.
 
+
+### `map_object`
+
+In addition, `rounder` offers you a `map_object()` function, which enables you to run any function that takes a number and returns a number for all numbers in an object. This works like the following:
+
+```python
+>>> xy = {"x": [12, 33.3, 45.5, 3543.22], "y": [.45, .3554, .55223, .9911], "expl": "x and y values"}
+>>> r.round_object(r.map_object(lambda x: x**3/(1 - 1/x), xy, use_copy=True), 4, use_copy=True)
+{'x': [1885.0909, 38069.258, 96313.1475, 44495587353.9829], 'y': [-0.0746, -0.0248, -0.2077, -108.4126], 'expl': 'x and y values'}
+
+```
+
+You would have achieved the same result had you used `round` inside the `lambda` body:
+
+```python
+>>> r.map_object(lambda x: round(x**3/(1 - 1/x), 4), xy, use_copy=True)
+{'x': [1885.0909, 38069.258, 96313.1475, 44495587353.9829], 'y': [-0.0746, -0.0248, -0.2077, -108.4126], 'expl': 'x and y values'}
+
+```
+
+The latter approach, actually, will be quicker, as the full recursion is used just once, not twice, as it was done in the former example.
+
+
+If the function takes additional arguments, you can use a wrapper function to overcome this issue:
+
+```python
+>>> def forget(something): pass
+>>> def fun(x, to_forget):
+...     forget(to_forget)
+...     return x**2
+>>> def wrapper(x):
+...     return fun(x, "this can be forgotten")
+>>> r.map_object(wrapper, [2, 2, [3, 3, ], {"a": 5}])
+[4, 4, [9, 9], {'a': 25}]
+
+```
 
 # Examples
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# `rounding`: Rounding of numbers in complex Python objects
+# `rounder`: Rounding of numbers in complex Python objects
 
-`rounding` is a lightweight package for rounding float numbers in complex structures, such as dictionaries, lists, tuples, and sets, and any complex object that combines any number of such objects in any nested structure. The code is organized as a Python (Python >= 3.6 is required) package that can be installed from PyPi (`pip install rounding`), but as it is a one-file package, you can simply download the main module ([rounding.py](build/lib/rounding/rounding.py)) and use it directly in your project.
+`rounder` is a lightweight package for rounding float numbers in complex structures, such as dictionaries, lists, tuples, and sets, and any complex object that combines any number of such objects in any nested structure. The code is organized as a Python (Python >= 3.6 is required) package that can be installed from PyPi (`pip install rounder`), but as it is a one-file package, you can simply download the main module ([rounder.py](rounder/rounder.py)) and use it directly in your project.
 
 The package is useful mainly for presentation purposes, but in some cases, it can be useful in other situations as well.
 
-`rounding` offers you four functions for rounding complex objects:
+`rounder` offers you four functions for rounding complex objects:
 
 * `round_object(x, digits=0, use_copy=False)`, which rounds `x` to `digits` decimal places
 * `floor_object(x, use_copy=False)`, which rounds `x` down to the nearest integer
@@ -18,7 +18,7 @@ but it also offers a function for rounding numbers to significant digits:
 You can use `signif` in a simple way:
 
 ```python
->>> import rounding as r
+>>> import rounder as r
 >>> r.signif(1.1212, 3)
 1.12
 >>> r.signif(12.1239112, 5)
@@ -30,7 +30,7 @@ You can use `signif` in a simple way:
 
 The package is simple to use, but you have to remember that when you're working with mutable objects, such as dicts or lists, rounding them for printing purposes will affect the original object; no such effect, of course, will occur for immutable types (e.g., tuples and sets). To overcome this effect, simply use `use_copy=True` in the above functions for rounding objects (not in `signif`). If you do so, the function will create a copy of the object and work (and return) its deepcopy, not the original object.
 
-You can use `rounding` functions for rounding floats, but do remember that their behavior is slightly different than that of their `builtin` and `math` counterparts, as they do not throw an exception when a non-number object is used.
+You can use `rounder` functions for rounding floats, but do remember that their behavior is slightly different than that of their `builtin` and `math` counterparts, as they do not throw an exception when a non-number object is used.
 
 You can round a list, a tuple, a set (including a frozenset), a float `array.array`, and a dict:
 
@@ -89,7 +89,7 @@ array('d', [1.1, 2.4])
 
 ```
 
-Note that you do not have to worry about having non-roundable objects in a list (or whatever object you're feeding into `rounding` functions). Your objects can contain objects of any type, and only numbers will be rounded while all others will be remain untouched:
+Note that you do not have to worry about having non-roundable objects in a list (or whatever object you're feeding into `rounder` functions). Your objects can contain objects of any type, and only numbers will be rounded while all others will be remain untouched:
 
 ```python
 >>> r.round_object([1.122, "string", 2.4434, 2.45454545-2j], 1)
@@ -128,7 +128,7 @@ But most of all, you can apply rounding for any complex object, of any structure
 
 ```
 
-Perhaps it does not make much sense, but the point is that to round all the values in this structure, you would need to build a dedicated script for that. With `rounding`, this is a piece of cake:
+Perhaps it does not make much sense, but the point is that to round all the values in this structure, you would need to build a dedicated script for that. With `rounder`, this is a piece of cake:
 
 ```python
 >>> rounded_x = r.round_object(x, digits=2, use_copy=True)
@@ -169,7 +169,7 @@ First of all, all these functions will work the very same way as their original 
 
 ### Immutable types
 
-`rounding` does work with immutable types! It simply creates a new object, with rounded numbers:
+`rounder` does work with immutable types! It simply creates a new object, with rounded numbers:
 
 ```python
 >>> x = {1.12, 4.555}
@@ -196,7 +196,7 @@ Remember, however, that in the case of sets, you can get a shorter set then the 
 
 ### Generators and other unpickable objects
 
-This should be an extremely rare situation to request to round an object that contains a generator, or any other unpickable object. But if you happen to be in such a situation, be aware of some limitations of `rounding` functions.
+This should be an extremely rare situation to request to round an object that contains a generator, or any other unpickable object. But if you happen to be in such a situation, be aware of some limitations of `rounder` functions.
 
 As a rule, mainly for safety, generators are returned unchanged. This is a safe approach for the simple reason that you often choose to use a generator instead of, say, a list when the data you're processing can be too large for your machine's memory to handle. So:
 
@@ -230,23 +230,23 @@ But you have to remember that when you request a deepcopy (with `use_copy=True`)
 >>> gen_2_copied_rounded = r.round_object(gen_2, use_copy=True)
 Traceback (most recent call last):
     ...
-rounding.rounding.UnpickableObjectError
+rounder.rounder.UnpickableObjectError
 
 ```
 
-`range()` is pickable, so you can request a deepcopy of it in `rounding` functions. 
+`range()` is pickable, so you can request a deepcopy of it in `rounder` functions. 
 
 This is a rare situation, however, to include such objects in an object to be rounded. Remember about the above limitations, and you can either work with the original object (not its copy, so with default `use_copy=False`), or change it so that all its elements can be pickled.
 
 
 ### NumPy and Pandas
 
-`rounding` does not work with `numpy` and `pandas`: they have their own builtin methods for rounding, and using them will be much quicker.
+`rounder` does not work with `numpy` and `pandas`: they have their own builtin methods for rounding, and using them will be much quicker.
 
 
 ## Testing
 
-The package is covered with unit `pytest`s, located in the tests/ folder. In addition, the package uses `doctest`s, which are collected here, in this README, and in the main module, rounding.py. These `doctest`s serve mainly documentation purposes, and since they can be run any time during development and before with each release, this helps to check whether all the examples work fine.
+The package is covered with unit `pytest`s, located in the tests/ folder. In addition, the package uses `doctest`s, which are collected here, in this README, and in the main module, [rounder.py](rounder/rounder.py). These `doctest`s serve mainly documentation purposes, and since they can be run any time during development and before with each release, this helps to check whether all the examples work fine.
 
 
 ## OS

--- a/rounder/__init__.py
+++ b/rounder/__init__.py
@@ -1,4 +1,5 @@
-from .rounding import (
+from .rounder import (
+    map_object,
     round_object,
     floor_object,
     ceil_object,
@@ -6,4 +7,5 @@ from .rounding import (
     signif,
     UnpickableObjectError,
     NonNumericTypeError,
+    NonCallableError,
 )

--- a/rounder/rounder.py
+++ b/rounder/rounder.py
@@ -13,37 +13,41 @@ class NonNumericTypeError(Exception):
     pass
 
 
-def _do(func, value, digits, use_copy):
-    def convert(value):
-        if hasattr(value, "__dict__"):
-            convert(value.__dict__)
-            return value
-        if isinstance(value, complex):
+class NonCallableError(Exception):
+    pass
+
+
+def _do(func, obj, digits, use_copy):
+    def convert(obj):
+        if hasattr(obj, "__dict__"):
+            convert(obj.__dict__)
+            return obj
+        if isinstance(obj, complex):
             # this has to be checked before the Number check,
             # as complex is a Number
-            return convert(value.real) + convert(value.imag) * 1j
-        if isinstance(value, numbers.Number):
-            return func(value, *digits)
-        if isinstance(value, list):
-            value[:] = list(map(convert, value))
-            return value
-        if isinstance(value, (tuple, set, frozenset)):
-            return type(value)(convert(list(value)))
-        if isinstance(value, dict):
-            value.update(zip(value.keys(), convert(list(value.values()))))
-            return value  
-        if isinstance(value, array.array):
-            value[:] = array.array(value.typecode, convert(value.tolist()))
-            return value
+            return convert(obj.real) + convert(obj.imag) * 1j
+        if isinstance(obj, numbers.Number):
+            return func(obj, *digits)
+        if isinstance(obj, list):
+            obj[:] = list(map(convert, obj))
+            return obj
+        if isinstance(obj, (tuple, set, frozenset)):
+            return type(obj)(convert(list(obj)))
+        if isinstance(obj, dict):
+            obj.update(zip(obj.keys(), convert(list(obj.values()))))
+            return obj  
+        if isinstance(obj, array.array):
+            obj[:] = array.array(obj.typecode, convert(obj.tolist()))
+            return obj
 
-        return value
+        return obj
 
     if use_copy:
         try:
-            value = copy.deepcopy(value)
+            obj = copy.deepcopy(obj)
         except TypeError:
             raise UnpickableObjectError()
-    return convert(value)
+    return convert(obj)
 
 
 def signif(x, digits):
@@ -85,7 +89,7 @@ def signif(x, digits):
     return shifted / magnitude
 
 
-def round_object(value, digits=None, use_copy=False):
+def round_object(obj, digits=None, use_copy=False):
     """Round numbers in a Python object.
 
     Args:
@@ -109,16 +113,16 @@ def round_object(value, digits=None, use_copy=False):
     >>> round_object(obj, 2)
     {'number': 12.32, 'string': 'whatever', 'list': [122.45, 0.01]}
     """
-    return _do(builtins.round, value, [digits], use_copy)
+    return _do(builtins.round, obj, [digits], use_copy)
 
 
-def ceil_object(value, use_copy=False):
+def ceil_object(obj, use_copy=False):
     """Round numbers in a Python object, using the ceiling algorithm.
 
     This means rounding to the closest greater integer.
 
     Args:
-        x (any): any Python object
+        obj (any): any Python object
         use_copy (bool, optional): use a deep copy or work with the original
             object? Defaults to False, in which case mutable objects (a list
             or a dict, for instance) will be affect inplace.
@@ -136,16 +140,16 @@ def ceil_object(value, use_copy=False):
     >>> obj = {'number': 12.323, 'string': 'whatever', 'list': [122.45, .01]}
     >>> ceil_object(obj)
     {'number': 13, 'string': 'whatever', 'list': [123, 1]}"""
-    return _do(math.ceil, value, [], use_copy)
+    return _do(math.ceil, obj, [], use_copy)
 
 
-def floor_object(value, use_copy=False):
+def floor_object(obj, use_copy=False):
     """Round numbers in a Python object, using the floor algorithm.
 
     This means rounding to the closest smaller integer.
 
     Args:
-        x (any): any Python object
+        obj (any): any Python object
         use_copy (bool, optional): use a deep copy or work with the original
             object? Defaults to False, in which case mutable objects (a list
             or a dict, for instance) will be affect inplace.
@@ -164,14 +168,14 @@ def floor_object(value, use_copy=False):
     >>> floor_object(obj)
     {'number': 12, 'string': 'whatever', 'list': [122, 0]}
     """
-    return _do(math.floor, value, [], use_copy)
+    return _do(math.floor, obj, [], use_copy)
 
 
-def signif_object(value, digits=3, use_copy=False):
+def signif_object(obj, digits=3, use_copy=False):
     """Round numbers in a Python object to requested significant digits.
 
     Args:
-        x (any): any Python object
+        obj (any): any Python object
         digits (int, optional): number of digits.
         use_copy (bool, optional): use a deep copy or work with the original
             object? Defaults to False, in which case mutable objects (a list
@@ -200,7 +204,42 @@ def signif_object(value, digits=3, use_copy=False):
     >>> signif_object(obj, 3)
     {'number': 12.3, 'string': 'whatever', 'list': [122.0, 0.01]}
     """
-    return _do(signif, value, [digits], use_copy)
+    return _do(signif, obj, [digits], use_copy)
+
+
+def map_object(map_function, obj, use_copy=False):
+    """Maps recursively a Python object to a given function.
+
+    Args:
+        map_function: function that converts a number and returns a number
+        obj (any): any Python object
+        use_copy (bool, optional): use a deep copy or work with the original
+            object? Defaults to False, in which case mutable objects (a list
+            or a dict, for instance) will be affect inplace.
+
+    Returns:
+        any: the object with values mapped with the given map_function
+
+    >>> map_object(abs, -1)
+    1
+    >>> map_object(abs, [-2, -1, 0, 1, 2])
+    [2, 1, 0, 1, 2]
+    >>> round_object(
+    ...     map_object(
+    ...         math.sin,
+    ...         {0:0, 90: math.radians(90), 180: math.radians(180), 270: math.radians(270)}),
+    ...     3
+    ... )
+    {0: 0.0, 90: 1.0, 180: 0.0, 270: -1.0}
+    >>> map_object(abs, "string")
+    'string'
+    >>> obj = {'number': 12.323, 'string': 'whatever', 'list': [122.45, .01]}
+    >>> map_object(lambda x: signif(x**.5, 3), obj)
+    {'number': 3.51, 'string': 'whatever', 'list': [11.1, 0.1]}
+    """
+    if not callable(map_function):
+        raise NonCallableError
+    return _do(map_function, obj, [], use_copy)
 
 
 if __name__ == "__main__":

--- a/rounder/rounder.py
+++ b/rounder/rounder.py
@@ -35,7 +35,7 @@ def _do(func, obj, digits, use_copy):
             return type(obj)(convert(list(obj)))
         if isinstance(obj, dict):
             obj.update(zip(obj.keys(), convert(list(obj.values()))))
-            return obj  
+            return obj
         if isinstance(obj, array.array):
             obj[:] = array.array(obj.typecode, convert(obj.tolist()))
             return obj

--- a/setup.py
+++ b/setup.py
@@ -12,14 +12,14 @@ extras_requirements = {
 }
 
 setuptools.setup(
-    name="rounding",
-    version="0.2.1",
+    name="rounder",
+    version="0.3.1",
     author="Ruud van der Ham & Nyggus",
     author_email="nyggus@gmail.com",
-    description="A tool for rounding floats in complex structures",
+    description="A tool for rounding numbers in complex Python objects",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/nyggus/rounding",
+    url="https://github.com/nyggus/rounder",
     packages=setuptools.find_packages(),
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/tests/test_rounder_functions.py
+++ b/tests/test_rounder_functions.py
@@ -270,7 +270,7 @@ def test_signif_exception():
 
 
 def test_with_unpickable_objects():
-    gen = (i**2 for i in range(10))
+    gen = (i ** 2 for i in range(10))
     with pytest.raises(r.UnpickableObjectError):
         _ = r.round_object(gen, use_copy=True)
     _ = r.round_object(gen, use_copy=False)


### PR DESCRIPTION
This pull request:
* changes the name from `rounding` to `rounder`
* adds `map_object()` function
* changes `value` argument to `obj`
* adds tests for `map_object`
* adds examples with `map_object()` to README
* increments version to 0.3.1