### PR TITLE
Handle namedtuples and OrderedDict

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,22 @@ rounder.rounder.UnpickableObjectError
 This is a rare situation, however, to include unpickable objects in an object to be rounded. Remember about the above limitations, and you can either work with the original object (not its copy, so with default `use_copy=False`), or change it so that all its elements can be pickled.
 
 
+### List of types handled by `rounder`
+
+* `int`
+* `float`
+* `complex`
+* `set`
+* `frozenset`
+* `list`
+* `tuple`
+* `collections.namedtuple`
+* `typing.NamedTuple`
+* `dict`
+* `OrderedDict`
+* `array.array`
+
+
 ### NumPy and Pandas
 
 `rounder` does not work with `numpy` and `pandas`: they have their own builtin methods for rounding, and using them will be much quicker.

--- a/tests/test_rounder_functions.py
+++ b/tests/test_rounder_functions.py
@@ -435,3 +435,42 @@ def test_for_NamedTuples():
     assert r.map_object(lambda x: r.signif(x * 2, 2), x2) == X2(
         a=24.0, b=[88.0, 110.0, 130.0], c={"item1": 910.0, "item2": 180.0}
     )
+
+
+def test_for_OrderedDict():
+    from collections import OrderedDict
+
+    d = OrderedDict(a=1.1212, b=55.559)
+
+    d_rounded_copy = r.round_object(d, 2, True)
+    assert d_rounded_copy == OrderedDict(a=1.12, b=55.56)
+    assert d == OrderedDict(a=1.1212, b=55.559)
+
+    d_rounded_no_copy = r.round_object(d, 2, False)
+    assert d_rounded_no_copy == OrderedDict(a=1.12, b=55.56)
+    assert d == OrderedDict(a=1.12, b=55.56)
+
+    d = OrderedDict(
+        a=1.1212,
+        b=55.559,
+        c={"item1": "string", "item2": 3434.3434},
+        d=OrderedDict(d1=3434.3434, d2=[99.99, 1.2323 - 2j]),
+    )
+
+    d_rounded_copy = r.round_object(d, 2, True)
+    assert d_rounded_copy == OrderedDict(
+        [
+            ("a", 1.12),
+            ("b", 55.56),
+            ("c", {"item1": "string", "item2": 3434.34}),
+            (
+                "d",
+                OrderedDict([("d1", 3434.34), ("d2", [99.99, (1.23 - 2j)])]),
+            ),
+        ]
+    )
+    assert d != d_rounded_copy
+
+    d_rounded_no_copy = r.round_object(d, 2, False)
+    assert d_rounded_no_copy == d_rounded_copy
+    assert d_rounded_no_copy == d

--- a/tests/test_rounder_functions.py
+++ b/tests/test_rounder_functions.py
@@ -372,3 +372,34 @@ def test_with_class_instance():
     assert a.x == 11
     assert a.y[:3] == (45, 56, 67)
     assert a.y[3] == {"item1": 457, "item2": 91}
+
+
+def test_for_namedtuples():
+    from collections import namedtuple
+
+    X = namedtuple("X", "a b c")
+
+    x1 = X(12.12, 13.13, 14.94)
+    x1_rounded_copy = r.round_object(x1, 0, True)
+    assert x1_rounded_copy == X(12, 13, 15)
+    x1_rounded_no_copy = r.round_object(x1, 0, False)
+    assert x1_rounded_no_copy == X(12, 13, 15)
+    assert x1 == X(12.12, 13.13, 14.94)
+
+    x2 = X(
+        a=12.13,
+        b=[44.4444, 55.5555, 66.6666],
+        c={"item1": 457.1212, "item2": 90.0001},
+    )
+
+    assert r.round_object(x2.a, 0) == 12
+    assert r.round_object(x2.b, 0) == [44, 56, 67]
+    assert r.round_object(x2.c, 0) == {"item1": 457, "item2": 90}
+
+    assert r.signif_object(x2, 4) == X(
+        a=12.13, b=[44.0, 56.0, 67.0], c={"item1": 457.0, "item2": 90.0}
+    )
+
+    assert r.map_object(lambda x: r.signif(x * 2, 2), x2) == X(
+        a=24.0, b=[88.0, 110.0, 130.0], c={"item1": 910.0, "item2": 180.0}
+    )

--- a/tests/test_rounder_functions.py
+++ b/tests/test_rounder_functions.py
@@ -403,3 +403,35 @@ def test_for_namedtuples():
     assert r.map_object(lambda x: r.signif(x * 2, 2), x2) == X(
         a=24.0, b=[88.0, 110.0, 130.0], c={"item1": 910.0, "item2": 180.0}
     )
+
+
+def test_for_NamedTuples():
+    from typing import NamedTuple
+
+    X1 = NamedTuple("X1", [("a", float), ("b", tuple), ("c", dict)])
+
+    x1 = X1(12.12, 13.13, 14.94)
+    x1_rounded_copy = r.round_object(x1, 0, True)
+    assert x1_rounded_copy == X1(12, 13, 15)
+    x1_rounded_no_copy = r.round_object(x1, 0, False)
+    assert x1_rounded_no_copy == X1(12, 13, 15)
+    assert x1 == X1(12.12, 13.13, 14.94)
+
+    X2 = NamedTuple("X2", [("a", float), ("b", tuple), ("c", dict)])
+    x2 = X2(
+        a=12.13,
+        b=[44.4444, 55.5555, 66.6666],
+        c={"item1": 457.1212, "item2": 90.0001},
+    )
+
+    assert r.round_object(x2.a, 0) == 12
+    assert r.round_object(x2.b, 0) == [44, 56, 67]
+    assert r.round_object(x2.c, 0) == {"item1": 457, "item2": 90}
+
+    assert r.signif_object(x2, 4) == X2(
+        a=12.13, b=[44.0, 56.0, 67.0], c={"item1": 457.0, "item2": 90.0}
+    )
+
+    assert r.map_object(lambda x: r.signif(x * 2, 2), x2) == X2(
+        a=24.0, b=[88.0, 110.0, 130.0], c={"item1": 910.0, "item2": 180.0}
+    )


### PR DESCRIPTION
This pull requests

* adds handling of `collections.namedtuple`, `typing.NamedTuple` and `collections.OrderedDict`
* adds the corresponding tests
* adds to README a list of types handled by `rounder` 