### PR TITLE
Handle more objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Or even:
 
 ```
 
-# Examples
+# Types that `rounder` works with
 
 First of all, all these functions will work the very same way as their original counterparts (not for `signif`, which does not have one):
 
@@ -238,7 +238,31 @@ First of all, all these functions will work the very same way as their original 
 
 ```
 
-### Immutable types
+The power of `rounder`, however, comes with working with many other types, and in particular, complex objects that contains them. `rounder` will work with the following types:
+
+* `int`
+* `float`
+* `complex`
+* `set` and `frozenset`
+* `list`
+* `tuple`
+* `collections.namedtuple` and `typing.NamedTuple`
+* `dict`
+* `collections.defaultdict`
+* `collections.OrderedDict`
+* `collections.UserDict`
+* `collections.Counter`
+* `collections.deque`
+* `array.array`
+
+> Note that `rounder` will work with any type that follows the `collections.abc.Mapping` interface.
+
+> `collections.Counter`: Beware that using `rounder` for this type will affect the _values_ of the counter, which originally represent counts. In most cases, that would mean no effect on such counts (for `rounder.round_object()`, `rounder.ceil_object()` and `rounder.floor_object()`), but `rounder.signif_object()` and `rounder.map_object()` can change the counts. In rare situations, you can keep float values as values in the counter, then `rounder` will work as expected.
+
+> If `rounder` meets a type that is not recognized as any of the given above, it will simply return it untouched.
+
+
+## Immutable types
 
 `rounder` does work with immutable types! It simply creates a new object, with rounded numbers:
 
@@ -267,7 +291,7 @@ Remember, however, that in the case of sets, you can get a shorter set then the 
 ```
 
 
-### Generators and other unpickable objects
+## Generators and other unpickable objects
 
 This should be an extremely rare situation to request to round an object that contains a generator, or any other unpickable object. But if you happen to be in such a situation, be aware of some limitations of `rounder` functions.
 
@@ -312,32 +336,26 @@ rounder.rounder.UnpickableObjectError
 This is a rare situation, however, to include unpickable objects in an object to be rounded. Remember about the above limitations, and you can either work with the original object (not its copy, so with default `use_copy=False`), or change it so that all its elements can be pickled.
 
 
-### List of types handled by `rounder`
+## NumPy and Pandas
 
-* `int`
-* `float`
-* `complex`
-* `set`
-* `frozenset`
-* `list`
-* `tuple`
-* `collections.namedtuple`
-* `typing.NamedTuple`
-* `dict`
-* `OrderedDict`
-* `array.array`
+`rounder` does not work with `numpy` and `pandas`: they have their own builtin methods for rounding, and using them will be much quicker. However, if for some reason a `rounder` function meets a `pandas` or a `numpy` object on its way, like here:
 
+```python
+r.round_object(dict(
+    values=np.array([1.223, 3.3332, 2.323]),
+    something_else="whatever else"
+)
 
-### NumPy and Pandas
+```
 
-`rounder` does not work with `numpy` and `pandas`: they have their own builtin methods for rounding, and using them will be much quicker.
+then it will simply return the object untouched.
 
 
-## Testing
+# Testing
 
 The package is covered with unit `pytest`s, located in the [tests/ folder](tests/). In addition, the package uses `doctest`s, which are collected here, in this README, and in the main module, [rounder.py](rounder/rounder.py). These `doctest`s serve mainly documentation purposes, and since they can be run any time during development and before each release, they help to check whether all the examples are correct and work fine.
 
 
-## OS
+# OS
 
 The package is OS-independent. Its releases are checked in local machines, on Windows 10 and Ubuntu 20.04 for Windows, and in Pythonista for iPad.

--- a/rounder/rounder.py
+++ b/rounder/rounder.py
@@ -40,8 +40,6 @@ def _do(func, obj, digits, use_copy):
             return set(convert(list(obj)))
         if isinstance(obj, frozenset):
             return frozenset(convert(list(obj)))
-        if isinstance(obj, collections.Counter):
-            return obj
         if isinstance(obj, collections.abc.Mapping):
             for k, v in obj.items():
                 obj[k] = convert(obj[k])

--- a/rounder/rounder.py
+++ b/rounder/rounder.py
@@ -30,21 +30,32 @@ def _do(func, obj, digits, use_copy):
             obj[:] = list(map(convert, obj))
             return obj
         if isinstance(obj, tuple):
-            if hasattr(obj, "_fields"):  # it's a namedtuple
+            if hasattr(obj, "_fields"):
+                # it's a collections.namedtuple or a typing.NamedTuple
                 return obj._replace(**convert(obj._asdict()))
             else:
+                # regular tuple
                 return tuple(convert(list(obj)))
         if isinstance(obj, set):
             return set(convert(list(obj)))
         if isinstance(obj, frozenset):
             return frozenset(convert(list(obj)))
-        if isinstance(obj, (dict, collections.OrderedDict)):
-            obj.update(zip(obj.keys(), convert(list(obj.values()))))
+        if isinstance(obj, collections.Counter):
+            return obj
+        if isinstance(obj, collections.abc.Mapping):
+            for k, v in obj.items():
+                obj[k] = convert(obj[k])
             return obj
         if isinstance(obj, array.array):
             obj[:] = array.array(obj.typecode, convert(obj.tolist()))
             return obj
+        if isinstance(obj, collections.deque):
+            for i, elem in enumerate(obj):
+                obj[i] = convert(elem)
+            return obj
         if hasattr(obj, "__dict__"):
+            # this should be at the end as some of the above types
+            # have a __dict__ attribute
             convert(obj.__dict__)
             return obj
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ extras_requirements = {
 
 setuptools.setup(
     name="rounder",
-    version="0.3.2",
+    version="0.4.1",
     author="Ruud van der Ham & Nyggus",
     author_email="nyggus@gmail.com",
     description="A tool for rounding numbers in complex Python objects",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,8 +38,3 @@ def complex_object():
         },
     }
     return deepcopy(obj)
-
-
-@pytest.fixture
-def methods():
-    return "round", "ceil", "floor", "signif"

--- a/tests/test_rounder_functions.py
+++ b/tests/test_rounder_functions.py
@@ -366,7 +366,7 @@ def test_with_class_instance():
     # Note that you cannot create a copy of a class instance's attribute
     # and change it inplace in the instance:
     _ = r.map_object(lambda x: x * 2, a_copy.x)
-    assert a_copy.x != 20 and a_copy.x == 10
+    assert a_copy.x == 10
 
     _ = r.ceil_object(a)
     assert a.x == 11
@@ -474,3 +474,94 @@ def test_for_OrderedDict():
     d_rounded_no_copy = r.round_object(d, 2, False)
     assert d_rounded_no_copy == d_rounded_copy
     assert d_rounded_no_copy == d
+
+
+def test_for_defaultdict():
+    from collections import defaultdict
+
+    d = defaultdict(list)
+    d["a"] = 1.1212
+    d["b"] = 55.55656
+    d["c"] = 0.104343
+
+    d_rounded_copy = r.round_object(d, 2, True)
+
+    assert d_rounded_copy == defaultdict(a=1.12, b=55.56, c=0.10)
+    assert d != d_rounded_copy
+
+    d_rounded_no_copy = r.round_object(d, 2, False)
+    assert d_rounded_no_copy == defaultdict(a=1.12, b=55.56, c=0.10)
+    assert d == d_rounded_no_copy
+
+
+def test_for_UserDict():
+    from collections import UserDict
+
+    d = UserDict(dict(a=1.1212, b=55.559))
+
+    d_rounded_copy = r.round_object(d, 2, True)
+    assert d_rounded_copy == UserDict(dict(a=1.12, b=55.56))
+    assert d == UserDict(dict(a=1.1212, b=55.559))
+
+    d_rounded_no_copy = r.round_object(d, 2, False)
+    assert d_rounded_no_copy == UserDict(dict(a=1.12, b=55.56))
+    assert d == UserDict(dict(a=1.12, b=55.56))
+
+    d = UserDict(
+        dict(
+            a=1.1212,
+            b=55.559,
+            c={"item1": "string", "item2": 3434.3434},
+            d=UserDict(dict(d1=3434.3434, d2=[99.996, 1.2323 - 2j])),
+        )
+    )
+
+    d_rounded_copy = r.round_object(d, 2, True)
+    d_rounded_copy = UserDict(
+        dict(
+            a=1.12,
+            b=55.56,
+            c={"item1": "string", "item2": 3434.34},
+            d=UserDict(dict(d1=3434.34, d2=[100.0, 1.23 - 2j])),
+        )
+    )
+
+    assert d != d_rounded_copy
+
+    d_rounded_no_copy = r.round_object(d, 2, False)
+    assert d_rounded_no_copy == d_rounded_copy
+    assert d_rounded_no_copy == d
+
+
+def test_for_deque():
+    from collections import deque
+
+    d = deque([1.1222, 3.9989, 4.005])
+
+    d_rounded_copy = r.round_object(d, 2, True)
+
+    assert d_rounded_copy == deque([1.12, 4.0, 4.0])
+    assert d != d_rounded_copy
+
+    d_rounded_no_copy = r.round_object(d, 2, False)
+    assert d_rounded_no_copy == deque([1.12, 4.0, 4.0])
+    assert d == d_rounded_no_copy
+
+
+def test_for_Counter():
+    from collections import Counter
+
+    d = Counter([1.1222, 1.2222, 4.005])
+
+    d_rounded_copy = r.map_object(lambda x: 2 * x, d, True)
+    assert d_rounded_copy == Counter({1.1222: 2, 1.2222: 2, 4.005: 2})
+
+    d_rounded_no_copy = r.map_object(lambda x: 2 * x, d, False)
+    assert d_rounded_no_copy is d
+
+    d = Counter([1, 1, 2] + [5] * 12222)
+    d_rounded_copy = r.round_object(d, 2, True)
+    assert d_rounded_copy == d
+    d_rounded_copy = r.signif_object(d, 2, True)
+    assert d_rounded_copy != d
+    assert d_rounded_copy == Counter({1: 2, 2: 1, 5: 12000})


### PR DESCRIPTION
This pull requests comes with

* new types ('collections.OderedDict`, 'collections.UserDict`, 'collections.deque`, 'collections.OderedDict`, 'collections.defaultdict`, 'collections.Counter`), plus a general approach to handling mappings following `collections.abc.Mapping`
* new tests, for all the new types
* updated README, with a slightly changed organization: "Examples" section is renamed to "Types that `rounder` works with"; a warning about `collections.Counter` is added, as well as some notes about `numpy` and `pandas` objects
* version increment to 0.4.1