### PR TITLE
Fix `signif`

### DIFF
--- a/rounder/rounder.py
+++ b/rounder/rounder.py
@@ -182,7 +182,10 @@ def signif(x, digits):
     power = digits - d
     magnitude = math.pow(10, power)
     shifted = builtins.round(x * magnitude)
-    return shifted / magnitude
+    if x >= math.pow(10, digits):
+        return round(shifted / magnitude)
+    else:
+        return shifted / magnitude
 
 
 def round_object(obj, digits=None, use_copy=False):

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ extras_requirements = {
 
 setuptools.setup(
     name="rounder",
-    version="0.5.3",
+    version="0.5.4",
     author="Ruud van der Ham & Nyggus",
     author_email="nyggus@gmail.com",
     description="A tool for rounding numbers in complex Python objects",
@@ -24,7 +24,7 @@ setuptools.setup(
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent",
+        "Operating System :: OS Independent",p
     ],
     python_requires=">=3.6",
     extras_require=extras_requirements,

--- a/tests/test_rounder_functions.py
+++ b/tests/test_rounder_functions.py
@@ -781,3 +781,8 @@ def test_no_copy_for_MethodWrapperType():
     x = Whatever.__eq__
     x_rounded = r.round_object(x, use_copy=False)
     assert x_rounded is x
+
+
+def test_signif_edge_case():
+    assert r.signif(123123123123.0002, 7) == 123123100000
+    assert r.signif_object(123123123123.0002, 7) == 123123100000


### PR DESCRIPTION
This pull request comes with a small change to the `signif` function that enables one to get the following result:

```python
>>> rounder.signif(123123123123.0002, 7)
123123100000
```
instead of 
```python
>>> rounder.signif(123123123123.0002, 7)
123123099999.99998
```