### PR TITLE
Annotate code

### DIFF
--- a/rounder/rounder.py
+++ b/rounder/rounder.py
@@ -118,7 +118,8 @@ def _do(func, obj, digits, use_copy):
         if isinstance(obj, map):
             return convert_map(obj)
         if hasattr(obj, "__dict__"):
-            # placed at the end as some of the above (derived) types might have a __dict__
+            # placed at the end as some of the above (derived) types
+            # might have a __dict__
             if use_copy:
                 obj_copy = copy.copy(obj)
                 for k, v in obj_copy.__dict__.items():
@@ -342,7 +343,10 @@ def map_object(
     >>> round_object(
     ...     map_object(
     ...         math.sin,
-    ...         {0:0, 90: math.radians(90), 180: math.radians(180), 270: math.radians(270)}),
+    ...         {0:0, 90: math.radians(90),
+    ...          180: math.radians(180),
+    ...          270: math.radians(270)}
+    ...     ),
     ...     3
     ... )
     {0: 0.0, 90: 1.0, 180: 0.0, 270: -1.0}

--- a/rounder/rounder.py
+++ b/rounder/rounder.py
@@ -37,12 +37,7 @@ def types_lookup(type_name: str) -> Optional[Any]:
     return getattr(types, type_name, None)
 
 
-T = TypeVar("T")
-
-
-def _do(
-    func: Callable, obj: T, digits: List[Optional[int]], use_copy: bool
-) -> Union[Callable, map, filter, List[T], T]:
+def _do(func, obj, digits, use_copy):
 
     if type(obj) in (float, int):
         return func(obj, *digits)

--- a/setup.py
+++ b/setup.py
@@ -8,12 +8,13 @@ extras_requirements = {
         "wheel",
         "black",
         "pytest",
+        "mypy",
     ],
 }
 
 setuptools.setup(
     name="rounder",
-    version="0.6.1",
+    version="0.6.2",
     author="Ruud van der Ham & Nyggus",
     author_email="nyggus@gmail.com",
     description="A tool for rounding numbers in complex Python objects",


### PR DESCRIPTION
This pull request comes with type hints. In some cases, I used `Any`, but I think it's ok given the specificity of the functions.
Do the annotations increase readability? Not necessarily. But I see type hints are becoming a golden standard, so maybe we should add them? Doing so does not mean much cost (already done), but for some users a package with unannotated code seems unprofessional; let's do it to avoid such feelings.