### PR TITLE
Return int from signif

### DIFF
--- a/rounder/rounder.py
+++ b/rounder/rounder.py
@@ -20,11 +20,7 @@ from typing import Any, Callable, Dict, List, Optional, Union, TypeVar
 # Type declarations
 IntOrFloat = Union[int, float]
 
-<<<<<<< HEAD
-dispatch_table_store: Dict[Any, Any] = {}
-=======
 dispatch_table_store: Dict = {}
->>>>>>> Return int from signif
 
 
 class NonNumericTypeError(Exception):
@@ -327,11 +323,7 @@ def signif_object(obj: Any, digits: int = 3, use_copy: bool = False):
 
 
 def map_object(
-<<<<<<< HEAD
-    map_function: Callable[[List[IntOrFloat]], IntOrFloat],
-=======
     map_function: Callable[[IntOrFloat], IntOrFloat],
->>>>>>> Return int from signif
     obj: Any,
     use_copy: bool = False,
 ):
@@ -363,7 +355,6 @@ def map_object(
     >>> obj = {'number': 12.323, 'string': 'whatever', 'list': [122.45, .01]}
     >>> map_object(lambda x: signif(x**.5, 3), obj)
     {'number': 3.51, 'string': 'whatever', 'list': [11.1, 0.1]}
-    
     """
     if not callable(map_function):
         raise NonCallableError

--- a/rounder/rounder.py
+++ b/rounder/rounder.py
@@ -20,7 +20,11 @@ from typing import Any, Callable, Dict, List, Optional, Union, TypeVar
 # Type declarations
 IntOrFloat = Union[int, float]
 
+<<<<<<< HEAD
 dispatch_table_store: Dict[Any, Any] = {}
+=======
+dispatch_table_store: Dict = {}
+>>>>>>> Return int from signif
 
 
 class NonNumericTypeError(Exception):
@@ -214,9 +218,9 @@ def signif(x: IntOrFloat, digits: int) -> IntOrFloat:
     magnitude = math.pow(10, power)
     shifted = builtins.round(x * magnitude)
     if x >= math.pow(10, digits):
-        return round(shifted / magnitude)
+        return type(x)(round(shifted / magnitude))
     else:
-        return shifted / magnitude
+        return type(x)(shifted / magnitude)
 
 
 def round_object(obj: Any, digits: int = None, use_copy: bool = False) -> Any:
@@ -323,7 +327,11 @@ def signif_object(obj: Any, digits: int = 3, use_copy: bool = False):
 
 
 def map_object(
+<<<<<<< HEAD
     map_function: Callable[[List[IntOrFloat]], IntOrFloat],
+=======
+    map_function: Callable[[IntOrFloat], IntOrFloat],
+>>>>>>> Return int from signif
     obj: Any,
     use_copy: bool = False,
 ):

--- a/rounder/rounder.py
+++ b/rounder/rounder.py
@@ -363,6 +363,7 @@ def map_object(
     >>> obj = {'number': 12.323, 'string': 'whatever', 'list': [122.45, .01]}
     >>> map_object(lambda x: signif(x**.5, 3), obj)
     {'number': 3.51, 'string': 'whatever', 'list': [11.1, 0.1]}
+    
     """
     if not callable(map_function):
         raise NonCallableError

--- a/tests/test_rounder_functions.py
+++ b/tests/test_rounder_functions.py
@@ -523,10 +523,11 @@ def test_for_UserDict():
 
     assert d != d_rounded_copy
     assert type(d_rounded_copy) == UserDict
-    
+
     d_rounded_no_copy = r.round_object(d, 2, False)
     assert d_rounded_no_copy == d_rounded_copy
     assert d_rounded_no_copy == d
+
 
 def test_for_deque():
     from collections import deque
@@ -932,11 +933,18 @@ def test_no_copy_complex_object_with_map():
 def test_int_from_signif():
     assert isinstance(r.signif(12.2, 2), float)
     assert isinstance(r.signif(1222222, 3), int)
-    
-    x = [{"x": 2, "y": 45.556}, (175, 1222.3,), 2]
+
+    x = [
+        {"x": 2, "y": 45.556},
+        (
+            175,
+            1222.3,
+        ),
+        2,
+    ]
     assert isinstance(x[0]["x"], int)
     assert isinstance(x[2], int)
-    
+
     x_rounded = r.signif_object(x)
     assert isinstance(x_rounded[0]["x"], int)
     assert isinstance(x_rounded[2], int)

--- a/tests/test_rounder_functions.py
+++ b/tests/test_rounder_functions.py
@@ -927,3 +927,22 @@ def test_no_copy_complex_object_with_map():
         3.0,
     ]
     assert len(list(obj["dict"]["map"])) == 0
+
+
+def test_int_from_signif():
+    assert isinstance(r.signif(12.2, 2), float)
+    assert isinstance(r.signif(1222222, 3), int)
+    
+    x = [{"x": 2, "y": 45.556}, (175, 1222.3,), 2]
+    assert isinstance(x[0]["x"], int)
+    assert isinstance(x[2], int)
+    
+    x_rounded = r.signif_object(x)
+    assert isinstance(x_rounded[0]["x"], int)
+    assert isinstance(x_rounded[2], int)
+
+
+def test_int_return():
+    assert isinstance(r.round_object(10), int)
+    assert isinstance(r.ceil_object(10.234234), int)
+    assert isinstance(r.floor_object(10.234234), int)


### PR DESCRIPTION
This pull request comes with one change, to the `signif()` function. When it returns, it does not the following:
```python
if x >= math.pow(10, digits):
        return type(x)(round(shifted / magnitude))
    else:
        return type(x)(shifted / magnitude)
```
Note `type(x)` in both returns. Before the code did not use this, and this led to rare (but still) situations in which an integer was converted to a float. So, the code transformed sometimes `2` to `2.0`, when a complex object was transformed with `signif_object()`. The following test represents the situation:

```python
def test_int_from_signif():
    assert isinstance(r.signif(12.2, 2), float)
    assert isinstance(r.signif(1222222, 3), int)

    x = [
        {"x": 2, "y": 45.556},
        (
            175,
            1222.3,
        ),
        2,
    ]
    assert isinstance(x[0]["x"], int)
    assert isinstance(x[2], int)

    x_rounded = r.signif_object(x)
    assert isinstance(x_rounded[0]["x"], int)
    assert isinstance(x_rounded[2], int)
```
Now all is fine, but in the previous version, `x[0]["x"]` was not an `int` of 2, but a `float` of `2.0`, an irritating bug.

Now the issue is solved.

(For an unknown reason, one annotation was not merged in the previous pull request, so it is changed now.)