### PR TITLE
Map object with numbers number

### DIFF
--- a/rounder/rounder.py
+++ b/rounder/rounder.py
@@ -318,7 +318,7 @@ def signif_object(obj: Any, digits: int = 3, use_copy: bool = False):
 
 
 def map_object(
-    map_function: Callable[[IntOrFloat], IntOrFloat],
+    map_function: Callable[[Number], Number],
     obj: Any,
     use_copy: bool = False,
 ):

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ extras_requirements = {
 
 setuptools.setup(
     name="rounder",
-    version="0.6.4",
+    version="0.6.5",
     author="Ruud van der Ham & Nyggus",
     author_email="nyggus@gmail.com",
     description="A tool for rounding numbers in complex Python objects",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,7 @@
 import pytest
+import fractions
+import decimal
+
 from copy import deepcopy
 
 
@@ -36,5 +39,16 @@ def complex_object():
             "eb": {1.333, 2.999},
             "ec": dict(eca=1.565656, ecb=1.765765765),
         },
+    }
+    return deepcopy(obj)
+
+@pytest.fixture()
+def object_with_various_numbers():
+    obj = {
+        "complex number": 1.2-2j,
+        "string": "something nice, ha?",
+        "callable": lambda x: x ** 2,
+        "decimal": decimal.Decimal("1.2"),
+        "fraction": fractions.Fraction(1, 4),
     }
     return deepcopy(obj)

--- a/tests/test_rounder_functions.py
+++ b/tests/test_rounder_functions.py
@@ -1,7 +1,11 @@
 import asyncio
+import decimal
+import fractions
 import pytest
-import rounder as r
 import random
+import rounder as r
+
+from numbers import Number
 from copy import deepcopy
 from math import ceil, floor
 
@@ -229,10 +233,10 @@ def test_signif_object_for_complex_object_5_digits(complex_object):
 
 
 def test_for_complex_numbers():
-    assert r.round_object(1.934643 - 2j, 2) == 1.93 - 2j
-    assert r.ceil_object(1.934643 - 2j) == 2 - 2j
-    assert r.floor_object(1.934643 - 2j) == 1 - 2j
-    assert r.signif_object(1.934643 - 2j, 5) == 1.9346 - 2j
+    assert r.round_object(1.934643-2j, 2) == 1.93-2j
+    assert r.ceil_object(1.934643-2j) == 2-2j
+    assert r.floor_object(1.934643-2j) == 1-2j
+    assert r.signif_object(1.934643-2j, 5) == 1.9346-2j
 
 
 def test_signif_floats():
@@ -336,6 +340,16 @@ def test_map_object_squared(complex_object):
         "ec": {"eca": 2.451, "ecb": 3.118},
     }
     assert squared_complex_object["d"] == [1.262, 0.001]
+
+
+def test_map_Number(object_with_various_numbers):
+    def square(x: Number) -> Number:
+        return x ** 2
+    
+    squared_object = r.map_object(square, object_with_various_numbers)
+    assert squared_object["complex number"] == (1.44+4j)
+    assert squared_object["decimal"] == decimal.Decimal("1.44")
+    assert squared_object["fraction"] == fractions.Fraction(1, 16)    
 
 
 def test_with_class_instance():
@@ -448,7 +462,7 @@ def test_for_OrderedDict():
         a=1.1212,
         b=55.559,
         c={"item1": "string", "item2": 3434.3434},
-        d=OrderedDict(d1=3434.3434, d2=[99.99, 1.2323 - 2j]),
+        d=OrderedDict(d1=3434.3434, d2=[99.99, 1.2323-2j]),
     )
 
     d_rounded_copy = r.round_object(d, 2, True)
@@ -459,7 +473,7 @@ def test_for_OrderedDict():
             ("c", {"item1": "string", "item2": 3434.34}),
             (
                 "d",
-                OrderedDict([("d1", 3434.34), ("d2", [99.99, (1.23 - 2j)])]),
+                OrderedDict([("d1", 3434.34), ("d2", [99.99, (1.23-2j)])]),
             ),
         ]
     )
@@ -507,7 +521,7 @@ def test_for_UserDict():
             a=1.1212,
             b=55.559,
             c={"item1": "string", "item2": 3434.3434},
-            d=UserDict(dict(d1=3434.3434, d2=[99.996, 1.2323 - 2j])),
+            d=UserDict(dict(d1=3434.3434, d2=[99.996, 1.2323-2j])),
         )
     )
 
@@ -517,7 +531,7 @@ def test_for_UserDict():
             a=1.12,
             b=55.56,
             c={"item1": "string", "item2": 3434.34},
-            d=UserDict(dict(d1=3434.34, d2=[100.0, 1.23 - 2j])),
+            d=UserDict(dict(d1=3434.34, d2=[100.0, 1.23-2j])),
         )
     )
 


### PR DESCRIPTION
This merge request comes with the generalization of annotations for `map_ojbect()` to `numbers.Number`. The function works the same, as it did work with `numbers.Number` before, but the function's annotation suggested it worked only with `int` and `float` numbers.

I also added a minor stylistic change for complex numbers: I removed whitespaces surrounding the minus character in them.