### PR TITLE
33 improve type hints

### DIFF
--- a/rounder/rounder.py
+++ b/rounder/rounder.py
@@ -17,9 +17,6 @@ from fractions import Fraction
 from typing import Any, Callable, Dict, Optional, Union
 
 
-# Type declarations
-IntOrFloat = Union[int, float]
-
 dispatch_table_store: Dict = {}
 
 
@@ -175,7 +172,7 @@ def _do(func, obj, digits, use_copy):
     return convert(obj)
 
 
-def signif(x: IntOrFloat, digits: int) -> IntOrFloat:
+def signif(x: float, digits: int) -> float:
     """Round number to significant digits.
     Translated from Java algorithm available on
     <a href="http://stackoverflow.com/questions/202302">Stack Overflow</a>
@@ -360,7 +357,7 @@ def map_object(
 
 
 def map_object_clean(
-    map_function: Callable[[IntOrFloat], IntOrFloat],
+    map_function: Callable[[float], float],
     obj: Any,
     use_copy: bool = False,
 ):

--- a/rounder/rounder.py
+++ b/rounder/rounder.py
@@ -214,7 +214,7 @@ def signif(x: IntOrFloat, digits: int) -> IntOrFloat:
         return type(x)(shifted / magnitude)
 
 
-def round_object(obj: Any, digits: Optional[int] = None, use_copy: bool = False) -> Any:
+def round_object(obj: Any, digits: int = 0, use_copy: bool = False) -> Any:
     """Round numbers in a Python object.
     Args:
         obj (any): any Python object

--- a/rounder/rounder.py
+++ b/rounder/rounder.py
@@ -214,7 +214,7 @@ def signif(x: IntOrFloat, digits: int) -> IntOrFloat:
         return type(x)(shifted / magnitude)
 
 
-def round_object(obj: Any, digits: int = None, use_copy: bool = False) -> Any:
+def round_object(obj: Any, digits: Optional[int] = None, use_copy: bool = False) -> Any:
     """Round numbers in a Python object.
     Args:
         obj (any): any Python object

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ extras_requirements = {
 
 setuptools.setup(
     name="rounder",
-    version="0.6.5",
+    version="0.6.6",
     author="Ruud van der Ham & Nyggus",
     author_email="nyggus@gmail.com",
     description="A tool for rounding numbers in complex Python objects",


### PR DESCRIPTION
This pull request comes with minor improvements:
* `IntOrFloat` is removed, as `float` is enough in type hints: when you type hint `float`, `int` can be used and is fine for static checkers as `int` is consistent with `float`.
* `digits: int = None` (which was a static bug) is not `digits: int = 0`; it consistent with the interface of the other `rounder` functions. Note that the built-in `round()` function takes `ndigits=None` as default, and it works. However when `ndigits` is `None`, the function returns `int` while when `ndigits` is `0`, it returns a float. `rounder` functions do not have such functionality, so the default `digits` value should be `0` instead of `None`. We may consider introducing this functionality.